### PR TITLE
[Feat] : SecurityConfig 기본 설정 추가

### DIFF
--- a/src/main/java/team/mosk/api/server/global/config/SecurityConfig.java
+++ b/src/main/java/team/mosk/api/server/global/config/SecurityConfig.java
@@ -1,0 +1,56 @@
+package team.mosk.api.server.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import static org.springframework.web.cors.CorsConfiguration.*;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity security) throws Exception {
+        security.formLogin()
+                .disable();
+
+        security.sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+
+        security.csrf()
+                .disable()
+                .cors()
+                .configurationSource(corsConfigurationSource())
+                .and()
+                .authorizeHttpRequests()
+                .anyRequest().permitAll();
+
+        return security.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOriginPattern(ALL);
+        configuration.addAllowedHeader(ALL);
+        configuration.addAllowedMethod(ALL);
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+}


### PR DESCRIPTION
- PasswordEncoder 주입 시 BCryptPasswordEncoder 반환
- 테스트 편의를 위한 전체 요청 미인증 개방
- 정적 자산을 가지고있지 않은 API 서버로 WebSecurityCustomizer 제외