### PR TITLE
Hotfix : Store call 컬럼명 긴급수정

### DIFF
--- a/src/main/java/team/mosk/api/server/domain/store/model/persist/Store.java
+++ b/src/main/java/team/mosk/api/server/domain/store/model/persist/Store.java
@@ -34,6 +34,7 @@ public class Store extends BaseEntity {
 
     private String ownerName;
 
+    @Column(name = "call_number")
     private String call;
 
     private String crn; // 사업자등록 번호


### PR DESCRIPTION
Store call 컬럼명, 데이터베이스 예약어 중복으로 인한 배포실패로 긴급수정